### PR TITLE
Refactor PaperFoldMenuController to be more IB friendly.

### DIFF
--- a/Demo/Demo/AppDelegate.m
+++ b/Demo/Demo/AppDelegate.m
@@ -8,6 +8,7 @@
 
 #import "AppDelegate.h"
 #import "DemoMenuController.h"
+#import "DemoRootViewController.h"
 
 @implementation AppDelegate
 
@@ -23,7 +24,7 @@
     
     for (int i=0; i<8; i++)
     {
-        DemoMenuController *rootViewController = [[DemoMenuController alloc] init];
+        DemoRootViewController *rootViewController = [[DemoRootViewController alloc] init];
         [rootViewController setTitle:[NSString stringWithFormat:@"Root VC %i", i+1]];
         UINavigationController *rootNavController = [[UINavigationController alloc] initWithRootViewController:rootViewController];
         [viewControllers addObject:rootNavController];

--- a/Demo/Demo/DemoMenuController.m
+++ b/Demo/Demo/DemoMenuController.m
@@ -19,12 +19,19 @@
     self = [super initWithMenuWidth:menuWidth numberOfFolds:numberOfFolds];
     if (self)
     {
-        UIView *tableBgView = [[UIView alloc] init];
-        [tableBgView setBackgroundColor:[UIColor colorWithRed:0.170 green:0.166 blue:0.175 alpha:1.000]];
-        [self.menuTableView setBackgroundView:tableBgView];
-        [self.menuTableView setSeparatorStyle:UITableViewCellSeparatorStyleNone];
     }
     return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    UIView *tableBgView = [[UIView alloc] initWithFrame:self.view.bounds];
+    [tableBgView setBackgroundColor:[UIColor colorWithRed:0.170 green:0.166 blue:0.175 alpha:1.000]];
+    [self.menuTableView setBackgroundView:tableBgView];
+    [self.menuTableView setSeparatorStyle:UITableViewCellSeparatorStyleNone];
+    
+    [self performSelector:@selector(reloadMenu)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -46,6 +53,7 @@
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
             [[cell textLabel] setTextColor:[UIColor whiteColor]];
             [[cell textLabel] setHighlightedTextColor:[UIColor blackColor]];
+            [[cell textLabel] setBackgroundColor:[UIColor clearColor]];
             
             UIImageView *bgView = [[UIImageView alloc] initWithImage:[[UIImage imageNamed:@"cellBg.png"] stretchableImageWithLeftCapWidth:20 topCapHeight:20]];
             [cell setBackgroundView:bgView];

--- a/PaperFoldMenuController/PaperFoldMenuController.h
+++ b/PaperFoldMenuController/PaperFoldMenuController.h
@@ -37,11 +37,11 @@
 #import "ShadowView.h"
 
 @interface PaperFoldMenuController : UIViewController <PaperFoldViewDelegate, UITableViewDataSource, UITableViewDelegate>
-@property (nonatomic, strong) PaperFoldView *paperFoldView;
+@property (nonatomic, weak) PaperFoldView *paperFoldView;
 @property (nonatomic, strong) NSMutableArray *viewControllers;
-@property (nonatomic, strong) UITableView *menuTableView;
-@property (nonatomic, strong) UIView *contentView;
-@property (nonatomic, assign) id<PaperFoldMenuControllerDelegate> delegate;
+@property (nonatomic, weak) UITableView *menuTableView;
+@property (nonatomic, weak) UIView *contentView;
+@property (nonatomic, weak) id<PaperFoldMenuControllerDelegate> delegate;
 /**
  * Set and return the current view controller;
  */
@@ -50,6 +50,8 @@
  * Set and return the index of the current view controller
  */
 @property (nonatomic, assign) NSUInteger selectedIndex;
+@property (nonatomic, assign, readonly) float menuWidth;
+@property (nonatomic, assign, readonly) int numberOfFolds;
 /**
  * This method initialize the view controller with 
  * the width of the menu table view on the left


### PR DESCRIPTION
The summary of these changes are as follows:
1. Use weak semantics for subviews. (Inline with generated IB subviews properties semantics)
2. Defers setting up of subviews to `viewDidLoad`. (This helps in making it more IB friendly as IB won't be able to call `initWithMenuWidth:numberOfFolds:`, but if we exposes their properties, we can use user defined runtime attributes to set these value in IB)
3. Introduces `NSNotFound` for `selectedIndex`. (When no view controller is selected, we describe this state as NSNotFound)
4. Rewrote `selectIndex` and `selectedViewController`, making them observable by KVO. (Try to maintains only `selectedIndex` and make `selectedViewController` derives it value from `selectedIndex`)
5. Updates DemoMenuController. (Same as 2, defer setting up of subviews in `viewDidLoad`. We actually have to manually invoke `reloadMenu`)

Cheers!

Signed-off-by: Stan Chang Khin Boon khinboon@gmail.com
