### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,86 +12,86 @@ PaperFoldMenuController is a UITabBarController replacement, but displays the vi
 Usage
 -----
 
-#PaperFoldMenuController
+# PaperFoldMenuController
 
-##initWithMenuWidth:numberOfFolds
+## initWithMenuWidth:numberOfFolds
 Initialize PaperFoldMenuController
 
 	- (id)initWithMenuWidth:(float)menuWidth numberOfFolds:(int)numberOfFolds
 	
-####Parameters
-#####menuWidth
+#### Parameters
+##### menuWidth
 This value specifies the width of the table view in the left menu
-#####numberOfFolds
+##### numberOfFolds
 This value specifies the number of folds in the menu table view
 
-##setViewControllers:
+## setViewControllers:
 Sets the root view controllers. Title for each view controllers appears in the menu table view
 
 	- (void)setViewControllers:(NSMutableArray *)viewControllers
 
-####Parameters
-#####viewControllers
+#### Parameters
+##### viewControllers
 The array of custom view controllers to display on screen. The title of each view controllers are shown in the menu table view on the left. 
 
-##setSelectedIndex:
+## setSelectedIndex:
 Sets the current root view controller in contentView by index
 
 	- (void)setSelectedIndex:(NSUInteger)selectedIndex
 	
-####Parameters
-#####selectedIndex
+#### Parameters
+##### selectedIndex
 An integer value which is the index of the root  view controller in the viewControllers array.
 
-##showMenu:animated:
+## showMenu:animated:
 Show or hide the menu table view. 
 
 	- (void)showMenu:(BOOL)show animated:(BOOL)animated
 
-####Parameters
-#####show
+#### Parameters
+##### show
 A boolean value to indicate if the menu should be shown or hidden
-#####animated
+##### animated
 A boolean value to indicate if the folding/unfolding should be animated
-#####Discussion
+##### Discussion
 This method is automatically called with show=YES and animated=YES when a cell in menu table view is selected. 
 
-#PaperFoldMenuControllerDelegate
+# PaperFoldMenuControllerDelegate
 
-##paperFoldMenuController:shouldSelectViewController:
+## paperFoldMenuController:shouldSelectViewController:
 Ask the delegate whether the specified view controller should be made active
 
 	- (BOOL)paperFoldMenuController:(PaperFoldMenuController *)paperFoldMenuController shouldSelectViewController:(UIViewController *)viewController
 
-####Parameters
-#####paperFoldMenuController
+#### Parameters
+##### paperFoldMenuController
 The paperfold menu controller containing the viewController.
-#####viewController
+##### viewController
 The view controller selected in the menu
-#####Discussion
+##### Discussion
 The paperfold menu controller calls this method in response to the user tapping on the left menu. You can use this method to dynamically decide whether the view controller should be made active.
 
-##paperFoldMenuController:didSelectViewController:
+## paperFoldMenuController:didSelectViewController:
 The paperfold menu controller calls this method in response to the user tapping the left menu, after the viewController is made active.
 
 	- (void)paperFoldMenuController:(PaperFoldMenuController *)paperFoldMenuController didSelectViewController:(UIViewController *)viewController
 
-####Parameters
-#####paperFoldMenuController
+#### Parameters
+##### paperFoldMenuController
 The paperfold menu controller containing the viewController.
-#####viewController
+##### viewController
 The view controller selected in the menu
 
 
-##paperFoldMenuController:shouldFoldMenuToRevealViewController:
+## paperFoldMenuController:shouldFoldMenuToRevealViewController:
 Ask the delegate if the menu table view should be folded to reveal the selected view controller
 
 	- (BOOL)paperFoldMenuController:(PaperFoldMenuController *)paperFoldMenuController shouldFoldMenuToRevealViewController:(UIViewController *)viewController;
 
-####Parameters
-#####paperFoldMenuController
+#### Parameters
+##### paperFoldMenuController
 The paperfold menu controller containing the viewController.
-#####viewController
+##### viewController
 The view controller selected in the menu
 
 	


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
